### PR TITLE
Fixes for data and seeds

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,10 +2,12 @@ class Form < ActiveRecord::Base
   has_many :form_fields, :order => '-position DESC, id ASC'
   has_one :pdf
   has_many :submissions
-  attr_accessible :number, :title, :form_fields_attributes, :icr_reference_number, :omb_control_number, :omb_expiration_date, :options, :start_content, :agency_name
-  validates_presence_of :number, :title, :start_content, :agency_name
+  attr_accessible :number, :title, :form_fields_attributes, :icr_reference_number, :omb_control_number, :omb_expiration_date, :options, :start_content, :agency_name, :published_at
+  validates_presence_of :number, :title, :start_content, :agency_name, :published_at
   validates_uniqueness_of :number
   accepts_nested_attributes_for :form_fields, :reject_if => :all_blank, :allow_destroy => true
+
+  before_validation :set_default_values
 
   def as_json(options = {})
     super(options.merge(:only => [:number, :title, :icr_reference_number, :omb_control_number, :omb_expiration_date]))
@@ -13,5 +15,9 @@ class Form < ActiveRecord::Base
 
   def to_param
     self.number.parameterize
+  end
+
+  def set_default_values
+    self.published_at = Time.now if published_at.nil?
   end
 end

--- a/db/json/i3.json
+++ b/db/json/i3.json
@@ -1,8 +1,10 @@
-{ 
-  "form": 
+{
+  "form":
   {
     "number":"i3",
     "title":"Office of Innovation and Improvement - i3 Applicant Information",
+    "start_content":"Before you fill out the form, you will need these items...",
+    "agency_name":"Government Agency 1",
     "form_fields":[
       {
         "description":null,

--- a/db/json/sf-424.json
+++ b/db/json/sf-424.json
@@ -1,11 +1,13 @@
-{ 
-  "form": 
+{
+  "form":
     {
       "number":"SF-424",
       "icr_reference_number":"201305-4040-001",
       "omb_control_number":"4040-0001",
       "omb_expiration_date":"2016-06-30",
       "title":"Application for Federal Assistance",
+      "start_content":"Before you fill out the form, you will need these items...",
+      "agency_name":"Government Agency 1",
       "form_fields":
         [
           {

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,6 +1,6 @@
 namespace :mygov do
   namespace :forms do
-    
+
     desc "Import from JSON"
     task :import_from_json_file, [:json_file] => [:environment] do |t, args|
       if args[:json_file].blank?
@@ -8,7 +8,17 @@ namespace :mygov do
       else
         json = File.read(args[:json_file])
         parsed_json = JSON.parse(json)
-        form = Form.find_or_create_by_number(parsed_json["form"]["number"], :title => parsed_json["form"]["title"], :icr_reference_number => parsed_json["form"]["icr_reference_number"], :omb_control_number => parsed_json["form"]["omb_control_number"], :omb_expiration_date => parsed_json["form"]["omb_expiration_date"])
+
+        form = Form.find_or_create_by_number(parsed_json["form"]["number"],
+              :title => parsed_json["form"]["title"],
+              :icr_reference_number => parsed_json["form"]["icr_reference_number"],
+              :omb_control_number => parsed_json["form"]["omb_control_number"],
+              :omb_expiration_date => parsed_json["form"]["omb_expiration_date"],
+              :start_content => parsed_json["form"]["start_content"],
+              :agency_name => parsed_json["form"]["agency_name"],
+              :published_at => Time.now
+              )
+
         print "importing #{form.title}."
         pdf = form.build_pdf(parsed_json["form"]["pdf"]) if parsed_json["form"]["pdf"]
         form.pdf = pdf

--- a/script/backfill/update_form_data_with_required_attributes.rb
+++ b/script/backfill/update_form_data_with_required_attributes.rb
@@ -1,0 +1,3 @@
+Form.where(agency_name: nil).update_all(agency_name: "Government Agency 1")
+Form.where(start_content: nil).update_all(start_content: "Before you fill out this form, please obtain the following items...")
+Form.where(published_at: nil).update_all(published_at: Time.now)

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -6,7 +6,8 @@ describe Form do
       :title => 'Form Title',
       :number => 'F-1',
       :start_content => 'Before you begin filling out the form, make sure that you have the following materials...',
-      :agency_name => 'Test Government Agency'
+      :agency_name => 'Test Government Agency',
+      :published_at => Time.now
     }
   end
 
@@ -15,9 +16,34 @@ describe Form do
   it { should have_many :form_fields }
   it { should have_one :pdf }
 
-  it "creates a new object with valid attributes" do
-    Form.create!(@valid_attributes)
+
+  context "Valid form objects" do
+    it "creates a valid object with valid attributes" do
+      Form.create!(@valid_attributes).should be_valid
+    end
+
+    it "saves a default value for published_at when it has not been set" do
+      @valid_attributes.delete(:published_at)
+      new_form = Form.new(@valid_attributes)
+
+      new_form.save
+      expect(new_form.published_at).to_not be_nil
+    end
   end
+
+
+  context "Invalid form objects" do
+    [:number, :title, :start_content, :agency_name].each do |attr|
+      it "should not be valid with a missing '#{attr}'' attribute" do
+        form = Form.new(@valid_attributes)
+        form.send("#{attr.to_s}=", nil)
+        form.should_not be_valid
+      end
+    end
+  end
+
+
+
 
   context "when the form has form fields, so with field orders, some without" do
     before do


### PR DESCRIPTION
Changes in this commit: 
• Create a backfill script to populate existing records with the new required attributes (published_at, agency_name, start_content)
• Added published_at as a required attribute for the form model
• Updated the existing seed script so that it adds in the new required attributes
